### PR TITLE
feat: allow different namings of taskfiles Taskfile*.y*ml

### DIFF
--- a/src/_task
+++ b/src/_task
@@ -3,25 +3,34 @@ local state line
 declare -A opt_args
 
 _task_get_tasks () {
-  sed '1,/tasks:/d' Taskfile.yml | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk '{ print $1 }'
+  local taskfile=$1
+
+  sed '1,/tasks:/d' $taskfile | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk '{ print $1 }'
   while read included_task
   do
-    taskfile_path=$(sed "1,/$included_task:/d" Taskfile.yml | grep -m 1 -iwE "^\  \ \ taskfile: .*$" | awk '{ print $2 }')
+    taskfile_path=$(sed "1,/$included_task:/d" $taskfile | grep -m 1 -iwE "^\  \ \ taskfile: .*$" | awk '{ print $2 }')
     sed '1,/tasks:/d' $taskfile_path | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk -v included_task="$included_task" '{ print included_task":"$1 }'
-    
-  done < <(sed '1,/includes:/d' Taskfile.yml | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk '{ print $1 }')
+
+  done < <(sed '1,/includes:/d' $taskfile | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk '{ print $1 }')
 }
 
 _task () {
   local state line
   typeset -A opt_args
+  local taskfile=""
 
   _arguments \
     '*: :->args'
-  if [ -f Taskfile.yml ]; then
-    compadd `_task_get_tasks`
+
+  # Use nullglob option to handle no matches gracefully
+  setopt local_options nullglob
+  local taskfiles=(Taskfile*.y*ml)
+
+  if (( ${#taskfiles} > 0 )); then
+    # Use the first matching taskfile
+    compadd `_task_get_tasks ${taskfiles[1]}`
   else
-   echo -e "\nNo taskfile found"
+    echo -e "\nNo taskfile found"
   fi
 }
 


### PR DESCRIPTION
The name `Taskfile.yml` was hardcoded this PR allows finding taskfiles with different spellings `Taskfile*.y*ml`